### PR TITLE
fix some coord mixups and ignore .vs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ compile_commands.json
 !makefile
 .cache
 .vscode
+/.vs
 perf.*
 !perf.sh
 *.gcda

--- a/src/collision.c
+++ b/src/collision.c
@@ -1030,7 +1030,7 @@ static void through_offset(mvec2 Pos0, mvec2 Pos1, int *__restrict__ pOffsetX, i
 }
 
 static bool is_through(SCollision *pCollision, int x, int y, int OffsetX, int OffsetY, mvec2 Pos0, mvec2 Pos1) {
-  if (x < 0 || y < 0 || x >= pCollision->m_MapData.width * 32 || y >= pCollision->m_MapData.width * 32)
+  if (x < 0 || y < 0 || x >= pCollision->m_MapData.width * 32 || y >= pCollision->m_MapData.height * 32)
     return false;
   int pos = get_pure_map_index(pCollision, vec2_init(x, y));
   unsigned char *pFrontIdx = pCollision->m_MapData.front_layer.data;

--- a/src/gamecore.c
+++ b/src/gamecore.c
@@ -813,7 +813,7 @@ void cc_tick_deferred(SCharacterCore *pCore) {
     for (int dy = -1; dy <= 1; ++dy) {
       for (int dx = -1; dx <= 1; ++dx) {
         // TODO: use the block idx +- 1 +- map_width
-        int Idx = (((int)vgety(pCore->m_Pos) >> 5) + dx) * pCore->m_pCollision->m_MapData.width + (((int)vgetx(pCore->m_Pos) >> 5) + dy);
+        int Idx = (((int)vgety(pCore->m_Pos) >> 5) + dy) * pCore->m_pCollision->m_MapData.width + (((int)vgetx(pCore->m_Pos) >> 5) + dx);
         Idx = iclamp(Idx, 0, pCore->m_pCollision->m_MapData.width * pCore->m_pCollision->m_MapData.height - 1);
         int Id = pCore->m_pWorld->m_Accelerator.m_pGrid->m_pTeeGrid[Idx];
         while (Id >= 0) {


### PR DESCRIPTION
## Summary
- use map height for the `is_through` y bounds check instead of map width
- fix the deferred tee grid neighbor lookup so `dx` applies to x and `dy` applies to y
- ignore `/.vs` so local Visual Studio files do not show up in git