### PR TITLE
fix invalid owner access and collision bounds

### DIFF
--- a/src/collision.c
+++ b/src/collision.c
@@ -43,7 +43,8 @@ static bool tile_exists_next(SCollision *pCollision, int Index) {
       ((pTileIdx[TileOnTheRight] == TILE_STOPS || pTileIdx[TileOnTheLeft] == TILE_STOPS)))
     return true;
   if (pTileIdx[TileBelow] == TILE_STOPA || pTileIdx[TileAbove] == TILE_STOPA ||
-      ((pTileIdx[TileBelow] == TILE_STOPS || pTileIdx[TileAbove] == TILE_STOPS) && pTileFlgs[TileBelow] | ROTATION_180 | ROTATION_0))
+      ((pTileIdx[TileBelow] == TILE_STOPS || pTileIdx[TileAbove] == TILE_STOPS) &&
+       (pTileFlgs[TileBelow] == ROTATION_180 || pTileFlgs[TileBelow] == ROTATION_0)))
     return true;
 
   if (pFrontIdx) {
@@ -51,7 +52,8 @@ static bool tile_exists_next(SCollision *pCollision, int Index) {
         ((pFrontIdx[TileOnTheRight] == TILE_STOPS || pFrontIdx[TileOnTheLeft] == TILE_STOPS)))
       return true;
     if (pFrontIdx[TileBelow] == TILE_STOPA || pFrontIdx[TileAbove] == TILE_STOPA ||
-        ((pFrontIdx[TileBelow] == TILE_STOPS || pFrontIdx[TileAbove] == TILE_STOPS) && pFrontFlgs[TileBelow] | ROTATION_180 | ROTATION_0))
+        ((pFrontIdx[TileBelow] == TILE_STOPS || pFrontIdx[TileAbove] == TILE_STOPS) &&
+         (pFrontFlgs[TileBelow] == ROTATION_180 || pFrontFlgs[TileBelow] == ROTATION_0)))
       return true;
     if ((pFrontIdx[TileOnTheRight] == TILE_STOP && pFrontFlgs[TileOnTheRight] == ROTATION_270) ||
         (pFrontIdx[TileOnTheLeft] == TILE_STOP && pFrontFlgs[TileOnTheLeft] == ROTATION_90))
@@ -65,7 +67,8 @@ static bool tile_exists_next(SCollision *pCollision, int Index) {
         ((pDoorIdx[TileOnTheRight] == TILE_STOPS || pDoorIdx[TileOnTheLeft] == TILE_STOPS)))
       return true;
     if (pDoorIdx[TileBelow] == TILE_STOPA || pDoorIdx[TileAbove] == TILE_STOPA ||
-        ((pDoorIdx[TileBelow] == TILE_STOPS || pDoorIdx[TileAbove] == TILE_STOPS) && pDoorFlgs[TileBelow] | ROTATION_180 | ROTATION_0))
+        ((pDoorIdx[TileBelow] == TILE_STOPS || pDoorIdx[TileAbove] == TILE_STOPS) &&
+         (pDoorFlgs[TileBelow] == ROTATION_180 || pDoorFlgs[TileBelow] == ROTATION_0)))
       return true;
     if ((pDoorIdx[TileOnTheRight] == TILE_STOP && pDoorFlgs[TileOnTheRight] == ROTATION_270) ||
         (pDoorIdx[TileOnTheLeft] == TILE_STOP && pDoorFlgs[TileOnTheLeft] == ROTATION_90))
@@ -1585,7 +1588,7 @@ int get_index(SCollision *pCollision, mvec2 PrevPos, mvec2 Pos) {
 }
 
 int entity(SCollision *pCollision, int x, int y, int Layer) {
-  if ((unsigned char)x >= pCollision->m_MapData.width || (unsigned char)y >= pCollision->m_MapData.height)
+  if (x < 0 || y < 0 || x >= pCollision->m_MapData.width || y >= pCollision->m_MapData.height)
     return 0;
 
   const int Index = pCollision->m_pWidthLookup[y] + x;

--- a/src/gamecore.c
+++ b/src/gamecore.c
@@ -120,7 +120,7 @@ void cc_unfreeze(SCharacterCore *pCore);
 void cc_take_damage(SCharacterCore *pCore, mvec2 Force);
 bool lsr_hit_character(SLaser *pLaser, mvec2 From, mvec2 To) {
   mvec2 At;
-  SCharacterCore *pOwnerChar = &pLaser->m_Base.m_pWorld->m_pCharacters[pLaser->m_Owner];
+  SCharacterCore *pOwnerChar = pLaser->m_Owner >= 0 ? &pLaser->m_Base.m_pWorld->m_pCharacters[pLaser->m_Owner] : NULL;
   SCharacterCore *pHit;
   bool pDontHitSelf = pLaser->m_Bounces == 0 && !pLaser->m_WasTele;
   if (pOwnerChar ? (!pOwnerChar->m_LaserHitDisabled && pLaser->m_Type == WEAPON_LASER) ||
@@ -255,7 +255,7 @@ void lsr_bounce(SLaser *pLaser) {
     }
   }
 
-  SCharacterCore *pOwnerChar = &pLaser->m_Base.m_pWorld->m_pCharacters[pLaser->m_Owner];
+  SCharacterCore *pOwnerChar = pLaser->m_Owner >= 0 ? &pLaser->m_Base.m_pWorld->m_pCharacters[pLaser->m_Owner] : NULL;
   if (pLaser->m_Energy <= 0 && !pLaser->m_TeleportCancelled && pOwnerChar && pOwnerChar->m_HasTelegunLaser && pLaser->m_Type == WEAPON_LASER) {
     mvec2 PossiblePos;
     bool Found = false;
@@ -2534,6 +2534,8 @@ void wc_create_explosion(SWorldCore *pWorld, mvec2 Pos, int Owner) {
   if (pWorld->particle)
     pWorld->particle(Pos, PARTICLE_TYPE_EXPLOSION, -1, pWorld->user_data);
 
+  SCharacterCore *pOwnerChar = Owner >= 0 ? &pWorld->m_pCharacters[Owner] : NULL;
+
   for (int i = 0; i < pWorld->m_NumCharacters; i++) {
     SCharacterCore *pChr = &pWorld->m_pCharacters[i];
     mvec2 Diff = vvsub(pChr->m_Pos, Pos);
@@ -2545,8 +2547,8 @@ void wc_create_explosion(SWorldCore *pWorld, mvec2 Pos, int Owner) {
       ForceDir = vnormalize_nomask(Diff);
     l = 1 - fclamp((l - EXPLOSION_INNER_RADIUS) / (EXPLOSION_RADIUS - EXPLOSION_INNER_RADIUS), 0.0f, 1.0f);
     float Strength;
-    if (Owner != -1)
-      Strength = pWorld->m_pCharacters[Owner].m_pTuning->m_ExplosionStrength;
+    if (pOwnerChar)
+      Strength = pOwnerChar->m_pTuning->m_ExplosionStrength;
     else
       Strength = pWorld->m_pTunings[0].m_ExplosionStrength;
 
@@ -2555,7 +2557,7 @@ void wc_create_explosion(SWorldCore *pWorld, mvec2 Pos, int Owner) {
       continue;
 
     pChr->m_HitNum += Dmg;
-    if (!pWorld->m_pCharacters[Owner].m_GrenadeHitDisabled || Owner == pChr->m_Id) {
+    if (!pOwnerChar || !pOwnerChar->m_GrenadeHitDisabled || Owner == pChr->m_Id) {
       if (pChr->m_Solo && Owner != pChr->m_Id)
         continue;
       cc_take_damage(pChr, vfmul(ForceDir, Dmg * 2));


### PR DESCRIPTION
few issues that i fixed:
- guard owner-based character array access in laser/explosion paths
- fix the vertical TILE_STOPS condition in collision preprocessing
- fix entity bounds checks for negative coordinates and maps wider/taller than 255