### PR TITLE
Fix default max speed calculation for speedup tiles when `MaxSpeed == 0` and Fix hook/weapon tele broad-phase detection

### DIFF
--- a/src/collision.c
+++ b/src/collision.c
@@ -775,7 +775,7 @@ bool init_collision(SCollision *__restrict__ pCollision, map_data_t *__restrict_
                 pCollision->m_pBroadIndicesBitField[Idx] |= BitIdx;
               if (pRowInfos[ix] & INFO_ISSOLID)
                 pCollision->m_pBroadSolidBitField[Idx] |= BitIdx;
-              if (pRowTele && (pRowTele[x] == TILE_TELEINHOOK || pRowTele[x] == TILE_TELEINWEAPON))
+              if (pRowTele && (pRowTele[ix] == TILE_TELEINHOOK || pRowTele[ix] == TILE_TELEINWEAPON))
                 pCollision->m_pBroadTeleInBitField[Idx] |= BitIdx;
             }
           }

--- a/src/gamecore.c
+++ b/src/gamecore.c
@@ -958,7 +958,7 @@ void cc_handle_skippable_tiles(SCharacterCore *pCore, int Index) {
       static const float MaxSpeedScale = 5.0f;
       if (MaxSpeed == 0) {
         float MaxRampSpeed = pCore->m_pTuning->m_VelrampRange / (50 * logf(fmaxf((float)pCore->m_pTuning->m_VelrampCurvature, 1.01f)));
-        MaxSpeed = fmaxf(MaxRampSpeed, pCore->m_pTuning->m_VelrampStart) / 50 * MaxSpeedScale;
+        MaxSpeed = fmaxf(MaxRampSpeed, pCore->m_pTuning->m_VelrampStart / 50) * MaxSpeedScale;
       }
 
       float CurrentDirectionalSpeed = vdot(Direction, pCore->m_Vel);


### PR DESCRIPTION
1. `MaxRampSpeed` was already in tick units, but `VelrampStart` was compared before being divided by 50, should be only important when `MaxSpeed == 0`
2. The hook/weapon tele detection was checking only the top-left tile instead of the current tile, so this tele could get skipped